### PR TITLE
#77805 fix license template

### DIFF
--- a/src/Commands/GenerateClient.php
+++ b/src/Commands/GenerateClient.php
@@ -144,17 +144,33 @@ abstract class GenerateClient extends Command
 
     private function copyLicenseToClientPackage(): void
     {
-        $source = $this->templatePath('LICENSE-template.md');
+        $internalSource = $this->internalTemplatePath('LICENSE-template.md');
+        $externalSource = $this->externalTemplatePath('LICENSE-template.md');
+        $source = !is_null($externalSource) && file_exists($externalSource) ? $externalSource : $internalSource;
+
         $dest = $this->outputDir . DIRECTORY_SEPARATOR . 'LICENSE.md';
-        if (!file_exists($dest)) {
+        if (!file_exists($dest) && file_exists($source)) {
             copy($source, $dest);
             $this->info("Template LICENSE.md copied to package");
         }
     }
 
-    protected function templatePath(string $path): string
+    protected function internalTemplatePath(string $path): string
     {
         return __DIR__ . '/../../templates/' . ltrim($path, '/');
+    }
+
+    protected function externalTemplatePath(string $path): ?string
+    {
+        $resultPath = null;
+
+        if ($this->templateDir) {
+            $resultPath = rtrim($this->templateDir, DIRECTORY_SEPARATOR)
+                . DIRECTORY_SEPARATOR
+                . ltrim($path, DIRECTORY_SEPARATOR);
+        }
+
+        return $resultPath;
     }
 
     private function recursiveClearDirectory(string $dir, int $level = 0)


### PR DESCRIPTION
Для лицензии сделал два источника:
- templates из самого laravel-openapi-client-generator;
- из templateDir.
Тем самым те, кто хочет чтобы их клиенты генерились со своей лицензией, те в свой template_dir должны засунуть LICENSE-template.md и он подгрузится.